### PR TITLE
Prevents module from blocking on 2nd+ region by including AWS region_name in IAM role names

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -6,7 +6,7 @@ resource "aws_iam_instance_profile" "default" {
 
 resource "aws_iam_role" "default" {
   count = (module.this.enabled && local.instance_profile_count == 0) ? 0 : 1
-  name  = module.this.id
+  name  = "${module.this.id}-${data.aws_region}"
   path  = "/"
   tags  = module.this.tags
 

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ locals {
   ) : null
 }
 
-data "aws_region" "default" {}
+data "aws_region" "current" {}
 
 data "aws_ami" "default" {
   most_recent = "true"


### PR DESCRIPTION
## what
Prevents the name of the IAM role, which is a global resource, from blocking the creation of a similar role when module is run in different region

## why
Terraform state is region-specific. So running this module in 2 diff regions for the same account means it blocks on the role-name being "already created"
